### PR TITLE
Update HTM version in environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - festim==1.3
     - pyparsing
-    - h-transport-materials==0.12.7
+    - h-transport-materials==0.16.1


### PR DESCRIPTION
Some materials, such as Eurofer, are not in the current version of htm defined in the environment. 

This PR updates that to the latest version