### PR TITLE
Fix dollarmaths

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -31,6 +31,7 @@ parse:
     # don't forget to list any other extensions you want enabled,
     # including those that are enabled by default!
     - amsmath
+    - dollarmath
 
 launch_buttons:
   notebook_interface: "jupyterlab"


### PR DESCRIPTION
#84 added `ansmath` extension to the config file. Which means we need to "reactivate" `dollarmath` which was activated by default previously.